### PR TITLE
Add 2.4.0 and 2.4.1 fabric-peer images

### DIFF
--- a/.github/workflows/hlf-image.yaml
+++ b/.github/workflows/hlf-image.yaml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       matrix:
         hlf-version:
-          - 2.2.0
-          - 2.2.3
-          - 2.3.0
-          - 2.3.2
+          - "2.2.0"
+          - "2.2.3"
+          - "2.3.0"
+          - "2.3.2"
+          - "2.4.0"
+          - "2.4.1"
     steps:
       -
         name: Checkout code

--- a/images/fabric-peer/2.4.0/Dockerfile
+++ b/images/fabric-peer/2.4.0/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.15.2-alpine3.12 as builder
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY cmd/ cmd/
+RUN CGO_ENABLED=0 go build -o launcher ./cmd/launcher
+
+
+FROM hyperledger/fabric-peer:amd64-2.4.0
+RUN mkdir -p /builders/golang/bin
+
+COPY --from=builder /workspace/launcher  /builders/golang/bin/externalcc
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/detect
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/build
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/release
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/run
+
+COPY images/fabric-peer/2.3.2/k8scc.yaml /builders/golang/bin/k8scc.yaml

--- a/images/fabric-peer/2.4.0/k8scc.yaml
+++ b/images/fabric-peer/2.4.0/k8scc.yaml
@@ -1,0 +1,15 @@
+---
+images:
+  golang: "hyperledger/fabric-ccenv:2.4.0"
+  java: "hyperledger/fabric-javaenv:2.4.0"
+  node: "hyperledger/fabric-nodeenv:2.4.0"
+
+builder:
+  resources:
+    memory_limit: "0.5G"
+    cpu_limit: "0.2"
+  env: []
+launcher:
+  resources:
+    memory_limit: "0.5G"
+    cpu_limit: "0.2"

--- a/images/fabric-peer/2.4.1/Dockerfile
+++ b/images/fabric-peer/2.4.1/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.15.2-alpine3.12 as builder
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY cmd/ cmd/
+RUN CGO_ENABLED=0 go build -o launcher ./cmd/launcher
+
+
+FROM hyperledger/fabric-peer:amd64-2.4.1
+RUN mkdir -p /builders/golang/bin
+
+COPY --from=builder /workspace/launcher  /builders/golang/bin/externalcc
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/detect
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/build
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/release
+RUN ln -s /builders/golang/bin/externalcc /builders/golang/bin/run
+
+COPY images/fabric-peer/2.3.2/k8scc.yaml /builders/golang/bin/k8scc.yaml

--- a/images/fabric-peer/2.4.1/k8scc.yaml
+++ b/images/fabric-peer/2.4.1/k8scc.yaml
@@ -1,0 +1,15 @@
+---
+images:
+  golang: "hyperledger/fabric-ccenv:2.4.1"
+  java: "hyperledger/fabric-javaenv:2.4.1"
+  node: "hyperledger/fabric-nodeenv:2.4.1"
+
+builder:
+  resources:
+    memory_limit: "0.5G"
+    cpu_limit: "0.2"
+  env: []
+launcher:
+  resources:
+    memory_limit: "0.5G"
+    cpu_limit: "0.2"


### PR DESCRIPTION
Since Hyperledger Fabric 2.4.0 and 2.4.1 were recently released, these new versions also need to be build.